### PR TITLE
Correct internal RPI project name, was conflicting with parent project name

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ###############################################################################
 
-PROJECT( RPI )
+PROJECT( RPI-Internal )
 
 # Define the minimum CMake version needed
 CMAKE_MINIMUM_REQUIRED( VERSION 2.6 )


### PR DESCRIPTION
Just one line to avoid confusion between two identical project names. It might be that the reverse change is preferable (change the parent name) especially if you want to separate those projects in the end. But for the time being and given the closeness of the release, this will just do the trick
