### PR TITLE
Correct bug that could make numiter almost infinite for very small displacements

### DIFF
--- a/RegistrationAddOn/itkStationaryVelocityFieldExponential.txx
+++ b/RegistrationAddOn/itkStationaryVelocityFieldExponential.txx
@@ -179,7 +179,9 @@ StationaryVelocityFieldExponential<TInputImage,TOutputImage>
 
 
   // take the ceil and threshold
-  numiter = static_cast<unsigned int>(numiterfloat + 1.0);
+  numiter = 0;
+  if (numiterfloat + 1 > 0)
+    numiter = static_cast<unsigned int>(numiterfloat + 1.0);
     
   //std::cout<<"numiter "<<numiter<<" -- numiterfloat "<<numiterfloat<<" -- divider "<<static_cast<InputPixelRealValueType>(1<<numiter) <<std::endl;
 


### PR DESCRIPTION
The title says it all. When my previous PR was merged manually a check on positivity of numiterfloat was removed. Therefore you could get in very specific cases a very large numiter (cast in unsigned int)

This corrects it.
