### PR TITLE
Add install targets for RegistrationAddOn

### DIFF
--- a/RegistrationAddOn/CMakeLists.txt
+++ b/RegistrationAddOn/CMakeLists.txt
@@ -51,7 +51,7 @@ set ( RegistrationAddOnSRCS
   itkRegistrationFactory-explicit-template.cxx
 )
 
-add_library ( RegistrationAddOn SHARED
+add_library (${PROJECT_NAME}
   ${RegistrationAddOnSRCS} 
   )
 
@@ -74,4 +74,11 @@ else (WIN32 AND NOT CYGWIN AND NOT MINGW)
    )
 endif(WIN32 AND NOT CYGWIN AND NOT MINGW)
 
+## #################################################################
+## Install rules
+## #################################################################
 
+install(TARGETS ${PROJECT_NAME}
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)


### PR DESCRIPTION
CMake corrections so that registration add on is installed correctly and therefore used for linux packaging
