### PR TITLE
Correct number of iterations calculation in TransformPoint

### DIFF
--- a/RegistrationAddOn/itkStationaryVelocityFieldTransform.txx
+++ b/RegistrationAddOn/itkStationaryVelocityFieldTransform.txx
@@ -145,15 +145,17 @@ TransformPoint(const InputPointType & point) const
 
     float numiterfloat = 2.0 +
             0.5 * vcl_log(maxnorm2)/vnl_math::ln2;
-    std::cout<<"Num iter float: "<<numiterfloat<<std::endl;
 
-    unsigned int constant=static_cast<unsigned int>(1<<static_cast<unsigned int>(abs(numiterfloat)));
+    unsigned int numiter = 0;
+    if (numiterfloat + 1 > 0)
+        numiter = static_cast<unsigned int>(numiterfloat + 1.0);
+
+    unsigned int constant = 1<<numiter;
 
     typedef typename itk::DivideByConstantImageFilter<VectorFieldType,float,VectorFieldType> DividerType;
     typename DividerType::Pointer Divider=DividerType::New();
     Divider->SetInput(m_VectorField);
     Divider->SetConstant( constant );
-    std::cout<<"divider "<<  static_cast<unsigned int>(1<<static_cast<unsigned int>(abs(numiterfloat))) <<std::endl;
 
     Divider->Update();
 


### PR DESCRIPTION
This corrects a bug in TransformPoint method. It was the same bug as in RegistrationProgrammingInterface/itkStationaryVelocityFieldExponential.txx before PR #1 . This patch corrects it in the same way.
