### PR TITLE
Silence some new gcc warnings.

### DIFF
--- a/examples/DiffeomorphicDemons/rpiDiffeomorphicDemons.cxx
+++ b/examples/DiffeomorphicDemons/rpiDiffeomorphicDemons.cxx
@@ -271,8 +271,6 @@ DiffeomorphicDemons< TFixedImage, TMovingImage, TTransformScalarType >
 
 
     // Type definition
-    typedef  typename  TransformType::ScalarType
-            ScalarType;
 
     typedef  typename  TransformType::VectorFieldType
             VectorFieldType;


### PR DESCRIPTION
With gcc-4.8.2 some new warnings are added to -Wall. Notably there is one that shows locally defined types that are not used. This patch set corrects those warnings.
