### PR TITLE
Remove new clang warning

### DIFF
--- a/RegistrationAddOn/itkFixedPointInverseDisplacementFieldImageFilter.txx
+++ b/RegistrationAddOn/itkFixedPointInverseDisplacementFieldImageFilter.txx
@@ -73,7 +73,7 @@ void FixedPointInverseDisplacementFieldImageFilter<TInputImage, TOutputImage>::G
 	if (inputPtr.IsNull()) {
 		itkExceptionMacro("\n Input is missing.");
 	}
-	if (!TInputImage::ImageDimension == TOutputImage::ImageDimension) {
+	if (TInputImage::ImageDimension != TOutputImage::ImageDimension) {
 		itkExceptionMacro("\n Image Dimensions must be the same.");
 	}
 


### PR DESCRIPTION
A quicky : removal of a new warning introduced by the new version of xcode. Not much really
