### PR TITLE
[ITK5.3rc04] adapt to new version of ITK

### DIFF
--- a/src/RegistrationAddOn/itkStationaryVelocityFieldTransform.h
+++ b/src/RegistrationAddOn/itkStationaryVelocityFieldTransform.h
@@ -145,7 +145,7 @@ public:
      * Generic constructors.
      */
     itkNewMacro( Self )
-    itkTypeMacro( StationaryVelocityField, Transform )
+    itkTypeMacro( StationaryVelocityFieldTransform, Transform )
 
     /**
      * Method not implemented for stationary velocity fields.

--- a/src/RegistrationAddOn/itkStationaryVelocityFieldTransform.txx
+++ b/src/RegistrationAddOn/itkStationaryVelocityFieldTransform.txx
@@ -34,7 +34,8 @@ void
 StationaryVelocityFieldTransform<TScalarType, NDimensions>::
 SetIdentity(void)
 {
-    TScalarType            value = 0;
+    itk::Vector<double, 3> value;
+    value.Fill(0);
     VectorFieldPointerType field = VectorFieldType::New();
     field->Allocate();
     field->FillBuffer(value);

--- a/src/RegistrationAddOn/rpiDisplacementFieldTransform.txx
+++ b/src/RegistrationAddOn/rpiDisplacementFieldTransform.txx
@@ -29,7 +29,8 @@ void
 DisplacementFieldTransform<TScalarType, NDimensions>::
 SetIdentity(void)
 {
-    TScalarType            value = 0;
+    itk::Vector<double, 3> value;
+    value.Fill(0);
     VectorFieldPointerType field = VectorFieldType::New();
     field->Allocate();
     field->FillBuffer(value);

--- a/src/common/rpiCommonTools.txx
+++ b/src/common/rpiCommonTools.txx
@@ -114,10 +114,14 @@ castEuler3DTransform(itk::Euler3DTransform<TInputScalarType> * input)
     // Create output parameters and center
     OutputParameterType oP(InputTransformType::ParametersDimension);
     OutputCenterType    oC;
-    for (int i=0; i<OutputTransformType::ParametersDimension; i++)
+    for (int i=0; i<static_cast<int>(OutputTransformType::ParametersDimension); i++)
+    {
         oP[i] = iP[i];
-    for (int i=0; i<OutputTransformType::OutputSpaceDimension; i++)
+    }
+    for (int i=0; i<static_cast<int>(OutputTransformType::OutputSpaceDimension); i++)
+    {
         oC[i] = iC[i];
+    }
 
     // Create the output transformation
     typename OutputTransformType::Pointer output = OutputTransformType::New();
@@ -156,9 +160,9 @@ castAffineTransform(itk::AffineTransform<TInputScalarType,3> * input)
     // Create output parameters and center
     OutputParameterType oP(InputTransformType::ParametersDimension);
     OutputCenterType    oC;
-    for (int i=0; i<OutputTransformType::ParametersDimension; i++)
+    for (int i=0; i<static_cast<int>(OutputTransformType::ParametersDimension); i++)
         oP[i] = iP[i];
-    for (int i=0; i<OutputTransformType::OutputSpaceDimension; i++)
+    for (int i=0; i<static_cast<int>(OutputTransformType::OutputSpaceDimension); i++)
         oC[i] = iC[i];
 
     // Create the output transformation
@@ -197,10 +201,14 @@ castMatrixOffsetTransform(itk::MatrixOffsetTransformBase<TInputScalarType,3,3> *
     // Create output parameters and center
     OutputParameterType oP(InputTransformType::ParametersDimension);
     OutputCenterType    oC;
-    for (int i=0; i<OutputTransformType::ParametersDimension; i++)
+    for (int i=0; i<static_cast<int>(OutputTransformType::ParametersDimension); i++)
+    {
         oP[i] = iP[i];
-    for (int i=0; i<OutputTransformType::OutputSpaceDimension; i++)
+    }
+    for (int i=0; i<static_cast<int>(OutputTransformType::OutputSpaceDimension); i++)
+    {
         oC[i] = iC[i];
+    }
 
     // Create the output transformation
     typename OutputTransformType::Pointer output = OutputTransformType::New();


### PR DESCRIPTION
Adapt https://github.com/Inria-Asclepios/RPI/pull/25 to branch `RPI_INTERFACE` which is used in medInria branch `dev`.

We could merge it in RPI_INTERFACE after the merge of [VTK9 PR](https://github.com/medInria/medInria-public/pull/1232), or create an other branch.

:m:

